### PR TITLE
Separate validated dims from bound dims

### DIFF
--- a/src/phantom_tensors/_internals.py
+++ b/src/phantom_tensors/_internals.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from functools import wraps
 from typing import Any, Callable, Iterable, Optional, Tuple, Type, TypeVar, Union, cast
 
-from typing_extensions import TypeAlias
+from typing_extensions import Final, TypeAlias
 
 import phantom_tensors._utils as _utils
 from phantom_tensors._utils import LiteralLike, NewTypeLike, UnpackLike
@@ -61,7 +61,8 @@ def check(shape_type: Tuple[ShapeDimType, ...], shape: Tuple[int, ...]) -> bool:
     # Maybe enable extra strict mode where we do that checking
 
     # E.g. Tensor[A, B, B, C] -> matches == {A: [0], B: [1, 2], C: [3]}
-    matches: defaultdict[ShapeDimType, list[int]] = defaultdict(list)
+    bound_symbols: defaultdict[ShapeDimType, list[int]] = defaultdict(list)
+    validated_symbols: defaultdict[ShapeDimType, list[int]] = defaultdict(list)
 
     # These can be cached globally -- are independent of match pattern
     # E.g. Tensor[Literal[1]] -> validators {Literal[1]: lambda x: x == 1}
@@ -84,15 +85,26 @@ def check(shape_type: Tuple[ShapeDimType, ...], shape: Tuple[int, ...]) -> bool:
             var_field_ind = n
             continue
 
+        # if variadic tuple is present, need to use negative indexing to reference
+        # location from the end of the tuple
+        CURRENT_INDEX: Final = n if var_field_ind is None else n - len(shape_type)
+
         # The following symbols bind to dimensions (by symbol-reference)
         # Some of them may also carry with them additional validation checks,
         # which need only be checked when the symbol is first bound
-        _match_list = matches[dim_symbol]
+        _match_list = bound_symbols[dim_symbol]
 
-        if _match_list or dim_symbol in validators:
+        if _match_list:
             # We have already encountered symbol; do not need to validate or
             # extract validation function
-            _match_list.append(n if var_field_ind is None else n - len(shape_type))
+            _match_list.append(CURRENT_INDEX)
+            continue
+
+        _validate_list = validated_symbols[dim_symbol]
+
+        if _validate_list or dim_symbol in validators:
+            del bound_symbols[dim_symbol]
+            _validate_list.append(CURRENT_INDEX)
             continue
 
         if _utils.is_newtype(dim_symbol):
@@ -105,26 +117,32 @@ def check(shape_type: Tuple[ShapeDimType, ...], shape: Tuple[int, ...]) -> bool:
                         f"NewType of supertype {_supertype}"
                     )
                 validators[dim_symbol] = lambda x, sp=_supertype: isinstance(x, sp)  # type: ignore
+            _match_list.append(CURRENT_INDEX)
             del _supertype
         elif isinstance(dim_symbol, TypeVar):
-            pass
+            _match_list.append(CURRENT_INDEX)
         elif _utils.is_literal(dim_symbol) and dim_symbol:
             _expected_literals = dim_symbol.__args__
             literal_check: LiteralCheck = lambda x, y=_expected_literals: any(
                 x == val for val in y
             )
             validators[dim_symbol] = literal_check
+            _validate_list.append(CURRENT_INDEX)
             del _expected_literals
 
         elif isinstance(dim_symbol, type) and issubclass(dim_symbol, int):
             validators[dim_symbol] = lambda x, type_=dim_symbol: isinstance(x, type_)  # type: ignore
+            _validate_list.append(CURRENT_INDEX)
         else:
             raise TypeError(
                 f"Got shape-type {shape_type} with dim {dim_symbol}. Valid dimensions "
                 f"are `type[int] | Unpack | TypeVar | NewType | Literal`"
             )
+        if not _match_list:
+            del bound_symbols[dim_symbol]
 
-        _match_list.append(n if var_field_ind is None else n - len(shape_type))
+        if not _validate_list:
+            del validated_symbols[dim_symbol]
 
     if var_field_ind is None and len(shape_type) != len(shape):
         # E.g.      type: Tensor[A, B, C]
@@ -138,13 +156,14 @@ def check(shape_type: Tuple[ShapeDimType, ...], shape: Tuple[int, ...]) -> bool:
 
     _bindings = DimBinder.bindings
 
-    for symbol, indices in matches.items():
+    for symbol, indices in bound_symbols.items():
         validation_fn = validators.get(symbol, None)
 
         if len(indices) == 1 and _bindings is None and validation_fn is None:
             continue
 
         actual_val = shape[indices[0]]
+
         if _bindings is None or symbol is Any or symbol is int:
             expected_val = actual_val
         else:
@@ -158,4 +177,10 @@ def check(shape_type: Tuple[ShapeDimType, ...], shape: Tuple[int, ...]) -> bool:
 
         if not all(expected_val == shape[index] for index in indices):
             return False
+
+    for symbol, indices in validated_symbols.items():
+        validation_fn = validators[symbol]
+        if not all(validation_fn(shape[index]) for index in indices):
+            return False
+
     return True


### PR DESCRIPTION
Now, only `NewType(<name>, int)` and `TypeVar` symbols bind during parsing. `int` subclasses do not.

Given:

```python
from phantom import Phantom
from phantom_tensors.array import SupportsArray as Array

from tests.arrlike import arr

class EvenOnly(int, Phantom, predicate=lambda x: x % 2 == 0):
    ...
```

Before:

```python
>>> parse(arr(2, 4), Array[EvenOnly, EvenOnly])
--------------------------------------
ParseError: "shape-(2, 4) doesn't match shape-type (EvenOnly=2, EvenOnly=2)"
```

After:

```python
>>> parse(arr(2, 4), Array[EvenOnly, EvenOnly])
arr(2, 4)
```